### PR TITLE
fix circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install adafruit-circuitpython-pcf8575
+    circup install adafruit_pcf8575
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)