### PR TITLE
comparison instead of bool function

### DIFF
--- a/adafruit_pcf8575.py
+++ b/adafruit_pcf8575.py
@@ -104,7 +104,7 @@ class PCF8575:
         :param int pin: The pin number
         """
 
-        return bool((self.read_gpio() >> pin) & 0x1)
+        return ((self.read_gpio() >> pin) & 0x1) == 1
 
 
 """


### PR DESCRIPTION
Changed to use comparison instead of `bool()` which matches what we ended up with over in https://github.com/adafruit/Adafruit_CircuitPython_PCF8574/pull/9